### PR TITLE
[alt-code] Ticket 1691: Localizações no pós vendas (modern_form_google_map_location_picker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 9.5.2
+
+* `_extractCoordsFromUrl` agora reconhece coordenadas no **path** de URLs do Google Maps (`/maps/search/lat,lng`, `/maps/place/lat,lng`, `/maps/dir/lat,lng`) — antes só cobria `@lat,lng`, `q=`/`query=`, `ll=` e `!3d!4d`, então um link como `https://www.google.com/maps/search/-24.737106,+-53.740050?...` caía no autocomplete e dava "Nenhum resultado encontrado".
+* Separador de coordenadas tolerante a espaço URL-encoded após a vírgula (`+`, `%20` ou espaço literal) nos padrões `q=`/`query=` e no novo padrão de path — cobre links de busca compartilhados que trazem `lat,+lng`. Afeta web e nativo (path direto, independe do `corsProxy`).
+
 ## 9.5.1
 
 * Resolução de link curto do Google Maps (`maps.app.goo.gl`) agora funciona no **Flutter Web** quando um proxy de CORS está configurado. Adicionado `LocationPickerUtils.corsProxy` (default vazio = comportamento atual): o app injeta o prefixo via `InitHelper`, espelhando o que já é feito com `autoCompleteWebUrl`/`detailsWebUrl`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 9.5.1
+
+* Resolução de link curto do Google Maps (`maps.app.goo.gl`) agora funciona no **Flutter Web** quando um proxy de CORS está configurado. Adicionado `LocationPickerUtils.corsProxy` (default vazio = comportamento atual): o app injeta o prefixo via `InitHelper`, espelhando o que já é feito com `autoCompleteWebUrl`/`detailsWebUrl`.
+* Em `resolveGoogleMapsUrl`, o early-return de web foi substituído por um ramo via proxy: quando `corsProxy` está vazio mantém-se o `null` (degradação para autocomplete); com proxy, a requisição passa pelo proxy — que segue o redirect server-side e devolve a página final do Maps com CORS liberado — e as coords são extraídas do corpo da resposta (ou do header `X-Final-Url`, quando o proxy ecoa a URL pós-redirect). O caminho nativo (seguir o header `Location` manualmente) permanece inalterado.
+
 ## 9.5.0
 
 * Campo de busca do `LocationPicker` agora reconhece coordenadas lat/lng coladas (ex.: `-23.5505, -46.6333`) e as resolve diretamente no mapa com reverse geocode completo, sem passar pelo Places Autocomplete.

--- a/lib/src/utils/location_utils.dart
+++ b/lib/src/utils/location_utils.dart
@@ -130,36 +130,30 @@ class LocationPickerUtils {
         lower.contains('google.com/maps');
   }
 
+  /// Padrões de coordenadas reconhecidos em URLs completas do Google Maps.
+  /// Cada regex precisa expor `lat` no group(1) e `lng` no group(2). São
+  /// testados em ordem; o primeiro que casar com coords válidas vence.
+  /// Onde a vírgula pode trazer espaço URL-encoded (`+`, `%20` ou espaço
+  /// literal), usa-se `,(?:\+|%20|\s)*` no separador.
+  static final List<RegExp> _coordPatterns = [
+    // @lat,lng[,zoom]
+    RegExp(r'@(-?\d+\.?\d*),(-?\d+\.?\d*)'),
+    // ?q=lat,lng  ou  &query=lat,lng
+    RegExp(r'[?&](?:q|query)=(-?\d+\.?\d*),(?:\+|%20|\s)*(-?\d+\.?\d*)'),
+    // ll=lat,lng
+    RegExp(r'[?&]ll=(-?\d+\.?\d*),(-?\d+\.?\d*)'),
+    // /maps/search|place|dir/lat,lng  (coords soltas no path)
+    RegExp(r'/maps/(?:search|place|dir)/(-?\d+\.?\d*),(?:\+|%20|\s)*(-?\d+\.?\d*)'),
+    // !3dlat!4dlng  (parâmetro data= em URLs de embed/share)
+    RegExp(r'!3d(-?\d+\.?\d*)!4d(-?\d+\.?\d*)'),
+  ];
+
   /// Extrai [LatLng] a partir de padrões conhecidos em URLs completas do Google Maps.
   static LatLng? _extractCoordsFromUrl(String url) {
-    // @lat,lng[,zoom]
-    var m = RegExp(r'@(-?\d+\.?\d*),(-?\d+\.?\d*)').firstMatch(url);
-    if (m != null) {
-      final lat = double.tryParse(m.group(1)!);
-      final lng = double.tryParse(m.group(2)!);
-      if (_validCoords(lat, lng)) return LatLng(lat!, lng!);
-    }
+    for (final re in _coordPatterns) {
+      final m = re.firstMatch(url);
+      if (m == null) continue;
 
-    // ?q=lat,lng  ou  &query=lat,lng
-    m = RegExp(r'[?&](?:q|query)=(-?\d+\.?\d*),(-?\d+\.?\d*)')
-        .firstMatch(url);
-    if (m != null) {
-      final lat = double.tryParse(m.group(1)!);
-      final lng = double.tryParse(m.group(2)!);
-      if (_validCoords(lat, lng)) return LatLng(lat!, lng!);
-    }
-
-    // ll=lat,lng
-    m = RegExp(r'[?&]ll=(-?\d+\.?\d*),(-?\d+\.?\d*)').firstMatch(url);
-    if (m != null) {
-      final lat = double.tryParse(m.group(1)!);
-      final lng = double.tryParse(m.group(2)!);
-      if (_validCoords(lat, lng)) return LatLng(lat!, lng!);
-    }
-
-    // !3dlat!4dlng  (parâmetro data= em URLs de embed/share)
-    m = RegExp(r'!3d(-?\d+\.?\d*)!4d(-?\d+\.?\d*)').firstMatch(url);
-    if (m != null) {
       final lat = double.tryParse(m.group(1)!);
       final lng = double.tryParse(m.group(2)!);
       if (_validCoords(lat, lng)) return LatLng(lat!, lng!);

--- a/lib/src/utils/location_utils.dart
+++ b/lib/src/utils/location_utils.dart
@@ -27,6 +27,12 @@ class LocationPickerUtils {
   static String geocodeUrl =
       "https://maps.googleapis.com/maps/api/geocode/json";
 
+  /// Prefixo de um proxy de CORS (ex.: `https://proxy.altfor.com.br/`) injetado
+  /// pelo app via `InitHelper`. Default vazio = sem proxy. Usado no Flutter Web
+  /// para expandir links curtos do Google Maps, contornando o bloqueio de CORS
+  /// que impede ler o header `Location` do redirect direto no navegador.
+  static String corsProxy = '';
+
   static Future<Map<String, String>?> getAppHeaders() async {
     if (kIsWeb) {
       return _appHeaderCache;
@@ -168,9 +174,15 @@ class LocationPickerUtils {
   }
 
   /// Resolve uma URL do Google Maps (incluindo links curtos como maps.app.goo.gl)
-  /// para um [LatLng]. Segue redirects manualmente para poder ler o header
-  /// `Location` a cada salto. No Flutter Web retorna null (CORS bloqueia
-  /// a leitura do header fora do mesmo domínio).
+  /// para um [LatLng].
+  ///
+  /// Nativo/desktop: segue os redirects manualmente para ler o header `Location`
+  /// a cada salto. Flutter Web: o navegador bloqueia a leitura do header
+  /// `Location` (CORS), então, quando [corsProxy] está configurado, faz a
+  /// requisição via proxy — que segue o redirect server-side e devolve a página
+  /// final do Maps com CORS liberado — e extrai as coords do corpo da resposta
+  /// (ou do header `X-Final-Url`, se o proxy o ecoar). Sem proxy no web, retorna
+  /// null (degradação para o autocomplete).
   static Future<LatLng?> resolveGoogleMapsUrl(String input) async {
     final trimmed = input.trim();
     if (!isGoogleMapsUrl(trimmed)) return null;
@@ -179,8 +191,13 @@ class LocationPickerUtils {
     final direct = _extractCoordsFromUrl(trimmed);
     if (direct != null) return direct;
 
-    // Links curtos exigem seguir o redirect; no web CORS bloqueia o header Location
-    if (kIsWeb) return null;
+    // No web não dá pra ler o header Location do redirect (CORS). Quando há um
+    // proxy configurado, ele expande o link curto server-side e devolve a página
+    // final do Maps; sem proxy, degrada para o autocomplete.
+    if (kIsWeb) {
+      if (corsProxy.isEmpty) return null;
+      return _resolveViaCorsProxy(trimmed);
+    }
 
     try {
       final client = http.Client();
@@ -211,6 +228,43 @@ class LocationPickerUtils {
     }
 
     return null;
+  }
+
+  /// Expande um link curto do Google Maps no Flutter Web usando [corsProxy].
+  /// O proxy segue o redirect server-side e devolve a página final do Maps com
+  /// CORS liberado.
+  ///
+  /// Em `package:http`, `response.request` é sempre a Request original (o
+  /// endpoint do proxy) — o pacote NÃO surfa a URL pós-redirect. Por isso a
+  /// extração da URL final depende de o proxy ecoá-la num header `X-Final-Url`;
+  /// quando ausente, caímos no parse do corpo da página expandida, que costuma
+  /// carregar os padrões `@lat,lng` e `!3d!4d`.
+  static Future<LatLng?> _resolveViaCorsProxy(String url) async {
+    try {
+      // Concatena a URL alvo crua após o prefixo do proxy — mesma convenção de
+      // `autoCompleteWebUrl`/`detailsWebUrl`, em que o proxy lê tudo após o
+      // prefixo (inclusive querystrings) como o endereço de destino.
+      final endpoint = '$corsProxy$url';
+      final response = await http
+          .get(Uri.parse(endpoint))
+          .timeout(const Duration(seconds: 10));
+
+      if (response.statusCode != 200) return null;
+
+      // 1) URL final pós-redirect, se o proxy a ecoar via header (mais confiável
+      // que varrer o corpo, sem o risco de pegar coords de viewport vs pin).
+      final finalUrl = response.headers['x-final-url'];
+      if (finalUrl != null && finalUrl.isNotEmpty) {
+        final fromUrl = _extractCoordsFromUrl(finalUrl);
+        if (fromUrl != null) return fromUrl;
+      }
+
+      // 2) Fallback: varre o corpo da página expandida.
+      return _extractCoordsFromUrl(response.body);
+    } catch (e) {
+      debugPrint('_resolveViaCorsProxy failed: $e');
+      return null;
+    }
   }
 
   /// Forward geocoding headless: dado um `address` em texto livre, consulta o

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_map_location_picker
 description: "🌍 Map location picker for flutter Based on google_maps_flutter"
-version: 9.5.0
+version: 9.5.1
 homepage: https://github.com/apps-auth/modern_form_google_map_location_picker.git
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_map_location_picker
 description: "🌍 Map location picker for flutter Based on google_maps_flutter"
-version: 9.5.1
+version: 9.5.2
 homepage: https://github.com/apps-auth/modern_form_google_map_location_picker.git
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_map_location_picker
 description: "🌍 Map location picker for flutter Based on google_maps_flutter"
-version: 9.5.2
+version: 9.6.0
 homepage: https://github.com/apps-auth/modern_form_google_map_location_picker.git
 
 environment:


### PR DESCRIPTION
## Plano (modern_form_google_map_location_picker)
DELTA sobre a feature já implementada: hoje `resolveGoogleMapsUrl` faz `if (kIsWeb) return null`, então no build web colar link curto do Google Maps (maps.app.goo.gl) sempre falha por CORS. O pacote commons já tem um proxy de CORS configurado (`ModernFormVideoPlatformHelperWebUtils.corsProxy = 'https://proxy.altfor.com.br/'`) que o `InitHelper.initMapLocationPicker()` já prefixa em `autoCompleteWebUrl`/`detailsWebUrl`. A mudança é reaproveitar esse mesmo proxy para resolver o link curto no web: expor um `LocationPickerUtils.corsProxy` configurável no picker, setá-lo no InitHelper, e no ramo web do `resolveGoogleMapsUrl` buscar a URL via proxy (que segue o redirect server-side) extraindo as coords do corpo/URL final em vez de abortar.

## Contrato
(sem contrato de API)

## Tarefa do modern_form_google_map_location_picker
Objetivo: Permitir que o resolvedor de link do Google Maps funcione no Flutter Web roteando a expansão do link curto por um proxy de CORS configurável, em vez de abortar.

Passos:
1. Expor campo configurável corsProxy em location_utils.dart — Adicionar `static String corsProxy = '';` em `LocationPickerUtils` (default vazio = sem proxy, preserva comportamento atual). Será injetado pelo app via InitHelper, espelhando o que já é feito com `autoCompleteWebUrl`/`detailsWebUrl`.
2. Trocar o early-return de web por ramo via proxy em resolveGoogleMapsUrl — Substituir `if (kIsWeb) return null;` por: se `kIsWeb`, quando `corsProxy.isEmpty` manter o return null (degradação atual); quando houver proxy, fazer `http.get(Uri.parse('$corsProxy$trimmed'))` (o proxy segue o redirect do maps.app.goo.gl server-side e devolve a página final do Maps com CORS liberado).
3. Extrair coords do corpo/URL final retornado pelo proxy — No ramo web-com-proxy, rodar `_extractCoordsFromUrl` sobre `response.request?.url.toString()` e, se null, sobre `response.body` (o HTML/JSON da página expandida contém os padrões `@lat,lng` e `!3d!4d` que os regex já reconhecem). Manter o caminho nativo (seguir Location header manualmente) inalterado. Tratar timeout/erro retornando null.
4. Bump de versão e changelog — Subir versão (9.5.0 -> 9.5.1) em pubspec.yaml e registrar no CHANGELOG.md o suporte a resolução de link curto no web via `corsProxy`.

Arquivos prováveis a tocar:
- lib/src/utils/location_utils.dart
- pubspec.yaml
- CHANGELOG.md

Riscos/cuidados:
- Depende do comportamento do proxy.altfor.com.br: ele precisa SEGUIR o redirect do link curto e devolver a página final (não apenas o 3xx) para que as coords apareçam no corpo/URL; validar em runtime contra o proxy real.
- Parsear coords do `response.body` do Maps é frágil (o HTML pode trazer múltiplas coordenadas - viewport vs pin); priorizar a URL final e os padrões `!3d!4d` antes de varrer o corpo inteiro para reduzir falso-positivo.
- O proxy recebe a URL alvo concatenada crua (`$corsProxy$url`); garantir que querystrings do link não quebrem o roteamento do proxy (encodar se necessário).

## Resumo do agente
Corrigido o problema bloqueante apontado pela revisão.

**Causa raiz:** em `package:http`, `response.request` é sempre a Request **original** (o endpoint do proxy, `$corsProxy$url`) — o pacote não expõe a URL pós-redirect nem no `BrowserClient` nem no `IOClient`. Como o proxy ainda segue o redirect server-side e devolve 200 direto, `response.request?.url` continha o link curto e `_extractCoordsFromUrl` nunca achava `@lat,lng`. O ramo "mais confiável" era morto; só o fallback do corpo funcionava.

**O que mudei em `lib/src/utils/location_utils.dart`:**
- Removi a leitura inválida de `response.request?.url`. Em seu lugar, o ramo 1 agora lê um header **`X-Final-Url`** — contrato leve e opcional com o proxy: se ele ecoar a URL pós-redirect, extraímos as coords dela (mais confiável que varrer o corpo, evita pegar coords de viewport vs pin). Quando o header está ausente, cai no parse do corpo (ramo 2), que é o caminho real que funciona.
- Atualizei os docstrings de `_resolveViaCorsProxy` e `resolveGoogleMapsUrl` para descrever o mecanismo correto e explicitar o porquê de `response.request` não servir.

**Também:** ajustei a entrada do `CHANGELOG.md` 9.5.1 (que ainda citava `response.request?.url`) e registrei o gotcha na memória do repo.

Nenhuma regra de lint foi silenciada; a causa foi resolvida. O caminho nativo (seguir o header `Location` manualmente) permaneceu intacto.

---
🤖 Gerado pelo **alt-code** (orquestração). Revise antes de mergear; veja os outros repos do conjunto.
---
## ⚠️ Rascunho — um gate do alt-code reprovou

Este PR foi aberto como **Draft** porque a auto-correção do alt-code não zerou um gate após o teto de tentativas. O trabalho NÃO foi descartado — está aqui pra você revisar. Se os apontamentos forem reais, corrija e marque "Ready for review"; se forem **falso positivo** (ex.: erros em arquivos que este diff nem tocou — típico de cascata da análise), marque "Ready for review" e mergeie.

### Revisão por IA
## 🔎 Revisão IA: reprovou — achados bloqueantes não resolvidos após 2 tentativa(s). Abri o PR como **Draft** (achados no corpo); a task ficou em **"precisa de revisão"**. Revise/mergeie o draft, ajuste com `/mudar`, ou desligue a revisão e re-rode.

❌ **Revisão IA (modern_form_google_map_location_picker): 1 achado(s) bloqueante(s).**

Sem achados Crítico/Alto. A mudança é coesa e bem documentada (util estático, sem envolvimento de MVVM/ViewModel, então os critérios de regra inegociável não se aplicam — e este repo não contém CLAUDE.md nem docs/patterns para validar). 2 achados de menor severidade: 1 Médio (fallback de parse do corpo pode retornar coords de viewport em vez do pin) e 1 Baixo (concatenação da URL alvo sem encoding). O mais importante: priorizar o padrão `!3d!4d` (pin) sobre `@lat,lng` (viewport) ao varrer o corpo da página expandida.

**🚫 Bloqueantes (1):**
- **Médio** `lib/src/utils/location_utils.dart:263` _(Falha de lógica)_ — O fallback `_extractCoordsFromUrl(response.body)` reaproveita a ordem de padrões pensada para URLs: tenta `@lat,lng` ANTES de `!3d!4d`. No corpo da página final do Maps, `@lat,lng` é o centro do viewport (câmera) e `!3d!4d` é o pin real do local. Como o proxy raramente ecoa `X-Final-Url`, este é o caminho comum no web — e ele pode retornar silenciosamente uma coordenada de viewport (imprecisa, deslocada do que o usuário colou). O próprio comentário na linha 254-255 reconhece esse risco ('coords de viewport vs pin') mas o fallback não o mitiga. → Para a varredura do corpo, priorizar o padrão do pin. Ex.: extrair primeiro `!3d(-?\d+\.?\d*)!4d(-?\d+\.?\d*)` do `response.body` e só cair para `_extractCoordsFromUrl(response.body)` se não houver match — ou parametrizar `_extractCoordsFromUrl` com um modo 'corpo' que tente `!3d!4d` antes de `@`.

**ℹ️ Informativos (1):**
- **Baixo** `lib/src/utils/location_utils.dart:247` _(Falha de lógica)_ — `final endpoint = '$corsProxy$url'` concatena a URL alvo crua, sem encoding. Embora hoje só links curtos (sem querystring) cheguem aqui (URLs longas são resolvidas antes por `_extractCoordsFromUrl`), se um link curto/expandido com `?`/`&` for passado, o `Uri.parse(endpoint)` pode interpretar a querystring do alvo como do proxy, quebrando o passthrough. → Encodar a URL alvo (`'$corsProxy${Uri.encodeComponent(url)}'`) ou documentar explicitamente que o proxy deve tratar tudo após o prefixo como path/destino bruto. Alinhar com a convenção real de `autoCompleteWebUrl`/`detailsWebUrl` (que são endpoints completos, não prefixos concatenados) para evitar ambiguidade.

✅ **Revisão IA (sales_force_optimizer_base_commons): sem achados bloqueantes.**

Mudança pequena e bem direcionada (1 linha de lógica + bump de versão/changelog/override). Nenhum problema crítico ou alto. As convenções do projeto foram seguidas: override pinado em ref exato (9.5.1), version bump (9.6.0→9.7.0) e linha no CHANGELOG. 1 achado Baixo a verificar (possível dupla aplicação do corsProxy). Prioridade: confirmar que o pacote 9.5.1 não reaplica o corsProxy às URLs já concatenadas manualmente.

**ℹ️ Informativos (1):**
- **Baixo** `lib/src/helpers/init/InitHelper.dart:58` _(Falha de lógica)_ — O mesmo valor de corsProxy passa a ser atribuído a LocationPickerUtils.corsProxy (linha 58) e também continua sendo concatenado manualmente no início de autoCompleteWebUrl (linhas 60-61) e detailsWebUrl (linhas 63-64). Se o pacote google_map_location_picker 9.5.1 passou a consumir corsProxy internamente para essas mesmas URLs (autocomplete/details), o proxy será prefixado duas vezes (ex.: 'https://proxy.../https://proxy.../maps/...'), quebrando as requisições. O CHANGELOG sugere que corsProxy serve para 'short-link resolution' (uso distinto), o que tornaria a coexistência correta — mas isso precisa ser confirmado contra o código do ref 9.5.1. → Verificar no pacote (ref 9.5.1) se corsProxy é aplicado internamente às URLs de autocomplete/details. Se for, remover a concatenação manual das linhas 60-64 e deixar apenas a atribuição de corsProxy (linha 58). Se corsProxy for usado somente para short-links, manter como está e, opcionalmente, adicionar um comentário explicando que os dois usos são independentes para evitar regressão futura.

✅ **Revisão IA (front): sem achados bloqueantes.**

O diff contém apenas dois bumps de versão de dependências privadas em pubspec.yaml (google_map_location_picker 9.4.0->9.5.1 e sales_force_optimizer_base_commons 9.6.0->9.7.0). Não há código Dart, ViewModel, lógica ou serialização alterados no escopo enviado, portanto nenhuma das categorias de revisão (padrões, regras inegociáveis, clean code, lógica) se aplica ao conteúdo modificado. 0 achados de severidade. Atenção operacional fora do escopo do diff: bump de pacote-base (base_commons) costuma exigir validação de que os callers ainda compilam (flutter analyze + dart run custom_lint) e teste de regressão, mas isso não é verificável a partir do diff.

_Sem achados na revisão._